### PR TITLE
Fix all the URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,11 @@ I prefer indentation with tabs for improved accessibility. But, I'd rather you u
 
 By participating in this project you agree to abide by the [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 
-[build status]: https://github.com/ChimeHQ/SwiftTreeSitter/actions
-[build status badge]: https://github.com/ChimeHQ/SwiftTreeSitter/workflows/CI/badge.svg
-[platforms]: https://swiftpackageindex.com/ChimeHQ/SwiftTreeSitter
-[platforms badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FChimeHQ%2FSwiftTreeSitter%2Fbadge%3Ftype%3Dplatforms
-[documentation]: https://swiftpackageindex.com/ChimeHQ/SwiftTreeSitter/main/documentation
+[build status]: https://github.com/tree-sitter/swift-tree-sitter/actions
+[build status badge]: https://github.com/tree-sitter/swift-tree-sitter/workflows/CI/badge.svg
+[platforms]: https://swiftpackageindex.com/tree-sitter/swift-tree-sitter
+[platforms badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ftree-sitter%2Fswift-tree-sitter%2Fbadge%3Ftype%3Dplatforms
+[documentation]: https://swiftpackageindex.com/tree-sitter/swift-tree-sitter/main/documentation
 [documentation badge]: https://img.shields.io/badge/Documentation-DocC-blue
 [discord]: https://discord.gg/esFpX6sErJ
 [discord badge]: https://img.shields.io/badge/Discord-purple?logo=Discord&label=Chat&color=%235A64EC


### PR DESCRIPTION
I didn't realize that the README contained URLs which are now out of date. Amazingly, Swift Package Index has enough smarts to automatically detect and fix this internally, so the links just need to be adjusted and everything will continue to work.